### PR TITLE
Refactor 2634 nnnnat dynamic transliteration

### DIFF
--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,17 +1,19 @@
-// latin base chars ISO
-const westernLangs = ["az", "da", "de", "en", "es", "ff", "fr", "ha", "hr", "hu", "ig", "is", "it", "jv", "ku", "ms", "nl", "no", "om", "pl", "pt", "ro", "sv", "sw", "tl", "tr", "uz", "vi", "yo"]; // eslint-disable-line max-len
+import { latinLangs } from "/lib/api/helpers";
 
-// client get shop lang
+// Wrapping the server metod/callback with a Promise
+// so the shops base language can be set as a const
+// using await inside the lazyLoadSlugify function
 const shopLang = new Promise((resolve, reject) => Meteor.call("shop/getBaseLanguage", (err, res) => err ? reject(err) : resolve(res)));
 
-
-// TODO: better comments for this func
-// TODO: conditional load based on shop lang
+// dynamic import of slugiy/transliteration.slugify
 let slugify;
 async function lazyLoadSlugify() {
   if (slugify) return;
+  // getting the shops base language
   const lang = await shopLang;
-  const mod = (westernLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  // if the shops language use latin based chars load slugify else load transliterations's slugify
+  const mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  // slugify is exported to modules.default while transliteration is exported to modules.slugify
   slugify = mod.default || mod.slugify;
 }
 

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -34,5 +34,5 @@ async function lazyLoadSlugify() {
  */
 export function getSlug(slugString) {
   Promise.resolve(lazyLoadSlugify());
-  return (slugString && slugify) ? slugify(slugString) : "";
+  return (slugString && slugify) ? slugify(slugString.toLowerCase()) : "";
 }

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,4 +1,12 @@
-import { slugify } from "transliteration";
+// TODO: better comments for this func
+// TODO: conditional load based on shop lang
+let slugify;
+async function lazyLoadSlugify() {
+  if (slugify) return;
+  const mod = await import("transliteration");
+  slugify = mod.default || mod.slugify;
+}
+
 
 /**
  * @name getSlug
@@ -11,5 +19,6 @@ import { slugify } from "transliteration";
  * @return {String} slugified string
  */
 export function getSlug(slugString) {
-  return slugString ? slugify(slugString) : "";
+  Promise.resolve(lazyLoadSlugify());
+  return (slugString && slugify) ? slugify(slugString) : "";
 }

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,18 +1,22 @@
-import { latinLangs } from "/lib/api/helpers";
-
-// Wrapping the server metod/callback with a Promise
-// so the shops base language can be set as a const
-// using await inside the lazyLoadSlugify function
-const shopLang = new Promise((resolve, reject) => Meteor.call("shop/getBaseLanguage", (err, res) => err ? reject(err) : resolve(res)));
+import { latinLangs, getShopLang } from "/lib/api/helpers";
 
 // dynamic import of slugiy/transliteration.slugify
 let slugify;
 async function lazyLoadSlugify() {
-  if (slugify) return;
+  let mod;
   // getting the shops base language
-  const lang = await shopLang;
-  // if the shops language use latin based chars load slugify else load transliterations's slugify
-  const mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  const lang = getShopLang();
+  // if slugify has been loaded but the language has changed
+  // to be a non latin based language then load transliteration
+  if (slugify && slugify.name === "replace" && latinLangs.indexOf(lang) === -1) {
+    mod = await import("transliteration");
+  } else if (slugify) {
+    // if slugify/transliteration is loaded and no lang change
+    return;
+  } else {
+    // if the shops language use latin based chars load slugify else load transliterations's slugify
+    mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  }
   // slugify is exported to modules.default while transliteration is exported to modules.slugify
   slugify = mod.default || mod.slugify;
 }

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,9 +1,17 @@
+// latin base chars ISO
+const westernLangs = ["az", "da", "de", "en", "es", "ff", "fr", "ha", "hr", "hu", "ig", "is", "it", "jv", "ku", "ms", "nl", "no", "om", "pl", "pt", "ro", "sv", "sw", "tl", "tr", "uz", "vi", "yo"]; // eslint-disable-line max-len
+
+// client get shop lang
+const shopLang = new Promise((resolve, reject) => Meteor.call("shop/getBaseLanguage", (err, res) => err ? reject(err) : resolve(res)));
+
+
 // TODO: better comments for this func
 // TODO: conditional load based on shop lang
 let slugify;
 async function lazyLoadSlugify() {
   if (slugify) return;
-  const mod = await import("transliteration");
+  const lang = await shopLang;
+  const mod = (westernLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
   slugify = mod.default || mod.slugify;
 }
 

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -1,9 +1,16 @@
 import url from "url";
-import { slugify } from "transliteration";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Router } from "/imports/plugins/core/router/lib";
 import { Shops } from "/lib/collections";
+
+let slugify;
+async function lazyLoadSlugify() {
+  if (slugify) return;
+  const mod = await import("transliteration");
+  slugify = mod.default || mod.slugify;
+}
+
 
 /**
  * @file Various helper methods
@@ -152,7 +159,8 @@ export function getCurrentTag() {
  * @return {String} slugified string
  */
 export function getSlug(slugString) {
-  return slugString ? slugify(slugString) : "";
+  Promise.resolve(lazyLoadSlugify());
+  return (slugString && slugify) ? slugify(slugString) : "";
 }
 
 /**

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -4,10 +4,20 @@ import { check } from "meteor/check";
 import { Router } from "/imports/plugins/core/router/lib";
 import { Shops } from "/lib/collections";
 
+// Array of ISO Language codes for all languages that use latin based char sets
+// list is based on this matrix http://w3c.github.io/typography/gap-analysis/language-matrix.html
+// list of lang codes https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+export const latinLangs = ["az", "da", "de", "en", "es", "ff", "fr", "ha", "hr", "hu", "ig", "is", "it", "jv", "ku", "ms", "nl", "no", "om", "pl", "pt", "ro", "sv", "sw", "tl", "tr", "uz", "vi", "yo"]; // eslint-disable-line max-len
+
+//
 let slugify;
 async function lazyLoadSlugify() {
   if (slugify) return;
-  const mod = await import("transliteration");
+  // getting the shops base language
+  const lang = Shops.findOne(getShopId()).languege;
+  // if the shops language use latin based chars load slugify else load transliterations's slugify
+  const mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  // slugify is exported to modules.default while transliteration is exported to modules.slugify
   slugify = mod.default || mod.slugify;
 }
 

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -9,14 +9,23 @@ import { Shops } from "/lib/collections";
 // list of lang codes https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 export const latinLangs = ["az", "da", "de", "en", "es", "ff", "fr", "ha", "hr", "hu", "ig", "is", "it", "jv", "ku", "ms", "nl", "no", "om", "pl", "pt", "ro", "sv", "sw", "tl", "tr", "uz", "vi", "yo"]; // eslint-disable-line max-len
 
-//
+// dynamic import of slugiy/transliteration.slugify
 let slugify;
 async function lazyLoadSlugify() {
-  if (slugify) return;
+  let mod;
   // getting the shops base language
-  const lang = Shops.findOne(getShopId()).languege;
-  // if the shops language use latin based chars load slugify else load transliterations's slugify
-  const mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  const lang = getShopLang();
+  // if slugify has been loaded but the language has changed
+  // to be a non latin based language then load transliteration
+  if (slugify && slugify.name === "replace" && latinLangs.indexOf(lang) === -1) {
+    mod = await import("transliteration");
+  } else if (slugify) {
+    // if slugify/transliteration is loaded and no lang change
+    return;
+  } else {
+    // if the shops language use latin based chars load slugify else load transliterations's slugify
+    mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  }
   // slugify is exported to modules.default while transliteration is exported to modules.slugify
   slugify = mod.default || mod.slugify;
 }
@@ -86,6 +95,18 @@ export function getShopName() {
   }).fetch()[0];
 
   return shop ? shop.name : "";
+}
+
+/**
+ * @name getShopLang
+ * @method
+ * @memberof Helpers
+ * @return {String} returns current shop language
+ */
+export function getShopLang() {
+  const shopId = getShopId();
+  const shop = Shops.findOne({ _id: shopId });
+  return shop ? shop.language : "";
 }
 
 /**

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -191,7 +191,7 @@ export function getCurrentTag() {
  */
 export function getSlug(slugString) {
   Promise.resolve(lazyLoadSlugify());
-  return (slugString && slugify) ? slugify(slugString) : "";
+  return (slugString && slugify) ? slugify(slugString.toLowerCase()) : "";
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16570,6 +16570,11 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
+    "slugify": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.2.9.tgz",
+      "integrity": "sha512-n0cdJ+kN3slJu8SbZXt/EHjljBqF6MxvMGSg/NPpBzoY7yyXoH38wp/ox20a1JaG1KgmdTN5Lf3aS9+xB2Y2aQ=="
+    },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "shallowequal": "^1.0.2",
     "shippo": "^1.3.1",
     "shopify-api-node": "^2.9.0",
+    "slugify": "^1.2.9",
     "sortablejs": "^1.7.0",
     "stripe": "^5.3.0",
     "sweetalert2": "^7.0.5",

--- a/server/api/core/utils.js
+++ b/server/api/core/utils.js
@@ -1,4 +1,11 @@
-import { slugify } from "transliteration";
+// TODO: better comments for this func
+// TODO: conditional load based on shop lang
+let slugify;
+async function lazyLoadSlugify() {
+  if (slugify) return;
+  const mod = await import("transliteration");
+  slugify = mod.default || mod.slugify;
+}
 
 /**
  * @name getSlug
@@ -11,5 +18,6 @@ import { slugify } from "transliteration";
  * @return {String} slugified string
  */
 export function getSlug(slugString) {
-  return slugString ? slugify(slugString) : "";
+  Promise.await(lazyLoadSlugify());
+  return (slugString && slugify) ? slugify(slugString) : "";
 }

--- a/server/api/core/utils.js
+++ b/server/api/core/utils.js
@@ -33,5 +33,5 @@ async function lazyLoadSlugify() {
  */
 export function getSlug(slugString) {
   Promise.await(lazyLoadSlugify());
-  return (slugString && slugify) ? slugify(slugString) : "";
+  return (slugString && slugify) ? slugify(slugString.toLowerCase()) : "";
 }

--- a/server/api/core/utils.js
+++ b/server/api/core/utils.js
@@ -1,10 +1,14 @@
-// TODO: better comments for this func
-// TODO: conditional load based on shop lang
+import { latinLangs } from "/lib/api/helpers";
+
+// dynamic import of slugiy/transliteration.slugify
 let slugify;
 async function lazyLoadSlugify() {
   if (slugify) return;
+  // getting the shops base language
   const lang = Meteor.call("shop/getBaseLanguage");
-  const mod = await import("transliteration");
+  // if the shops language use latin based chars load slugify else load transliterations's slugify
+  const mod = (latinLangs.indexOf(lang) >= 0) ? await import("slugify") : await import("transliteration");
+  // slugify is exported to modules.default while transliteration is exported to modules.slugify
   slugify = mod.default || mod.slugify;
 }
 

--- a/server/api/core/utils.js
+++ b/server/api/core/utils.js
@@ -3,6 +3,7 @@
 let slugify;
 async function lazyLoadSlugify() {
   if (slugify) return;
+  const lang = Meteor.call("shop/getBaseLanguage");
   const mod = await import("transliteration");
   slugify = mod.default || mod.slugify;
 }

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -58,7 +58,7 @@ const toDenormalize = [
  * @return {String} title - modified `title`
  */
 function createTitle(newTitle, productId) {
-  // exception product._id needed for cases then double triggering happens
+  // exception product._id needed for cases then double triggering happens3
   let title = newTitle || "";
   const titleCount = Products.find({
     title,

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -944,5 +944,17 @@ Meteor.methods({
     return Collections.Shops.update(shopId, {
       $set: { layout: shop.layout }
     });
+  },
+
+
+  /**
+   * TODO: method doc
+   */
+  "shop/getBaseLanguage"() {
+    if (!Reaction.hasPermission()) {
+      throw new Meteor.Error("access-denied", "Access Denied");
+    }
+    const shopId = Reaction.getShopId();
+    return Collections.Shops.findOne(shopId).language;
   }
 });

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -948,7 +948,11 @@ Meteor.methods({
 
 
   /**
-   * TODO: method doc
+   * @name shop/getBaseLanguage
+   * @method
+   * @memberof Methods/Shop
+   * @summary Return the shop's base language ISO code
+   * @return {String} ISO lang code
    */
   "shop/getBaseLanguage"() {
     if (!Reaction.hasPermission()) {


### PR DESCRIPTION
Fixes #2634

### Summary
- Dynamically load the slugify package for RC shops that have a latin based language selected as a primary language.
- Dynamically load the transliteration package for RC shops that have a non-latin based language selected as a primary language.

### Testing
*Western Langs*
- As an Admin select a product to edit and update the slug field and publish. Reaction should redirect to the new PDP with the updated slug in the URL.
- As an Admin create a new tag, publish then select the new tag in the tag navigation to see the new slug in the URL.

*Non-Western Langs*
- As an Admin change the RC shop's primary language to Chinese.
- Using google translate repeat the testing steps above with Chinese characters.