### PR TITLE
(refactor) use Events.Hooks instead of meteor collection hooks for cart events that trigger discount calculations

### DIFF
--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -1,6 +1,7 @@
 import { indexOf } from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Cart } from "/lib/collections";
+import { Hooks } from "/server/api";
 
 /**
 * Cart Hooks for Discounts

--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -1,4 +1,3 @@
-import { indexOf } from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Cart } from "/lib/collections";
 import { Hooks } from "/server/api";
@@ -11,19 +10,12 @@ import { Hooks } from "/server/api";
 * we could have done this in the core/cart transform
 * but this way this file controls the events from
 * the core/discounts plugin.
-* @todo just move so a single Hook.event and move all the
-* cart hooks to a single location.
 */
-Cart.after.update((userId, cart, fieldNames) => {
-  const trigger = ["discount", "billing", "shipping"];
-  if (cart) {
-    let { discount } = cart;
-    for (const field of fieldNames) {
-      if (indexOf(trigger, field) !== -1) {
-        discount = Meteor.call("discounts/calculate", cart);
-      }
-    }
-    // Update cart (without triggering more updates.)
-    Cart.direct.update({ _id: cart._id }, { $set: { discount } });
+Hooks.Events.add("afterCartUpdateCalculateDiscount", (cartId) => {
+  if (cartId) {
+    const cart = Cart.findOne({ _id: cartId });
+    const discount = Meteor.call("discounts/calculate", cart);
+
+    Cart.update({ _id: cart._id }, { $set: { discount } });
   }
 });

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Random } from "meteor/random";
-import { Reaction } from "/server/api";
+import { Reaction, Hooks } from "/server/api";
 import { Cart } from "/lib/collections";
 import { Discounts } from  "/imports/plugins/core/discounts/lib/collections";
 import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
@@ -165,12 +165,16 @@ export const methods = {
       Collection.update(selector, update);
     }
     // TODO: update a history record of transaction
-    // TODO: recalculate cart discounts (not simply 0)
-    return Collection.update(
+    const result = Collection.update(
       { _id: id },
       { $set: { discount: currentDiscount }, $pull: { billing: { _id: codeId } } },
       { multi: true }
     );
+
+    // calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", id);
+
+    return result;
   },
   /**
    * discounts/codes/apply

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -20,8 +20,9 @@ Hooks.Events.add("afterModifyQuantityInCart", (cartId, options) => {
   Logger.debug("after variant increment, call inventory/addReserve");
   // Look up cart to get items that have been added to it
   const items = Cart.findOne({ _id: cartId }).items;
+  
   // Item to increment quantity
-  const item = items.filter(i => i.productId === options.productId && i.variantId === options.variantId);
+  const item = items.filter(i => (i.product._id === options.productId && i.variants._id === options.variantId));
   Meteor.call("inventory/addReserve", item);
 });
 

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -6,31 +6,33 @@ import { registerInventory } from "../methods/inventory";
 /**
  * After cart update add invetory reservations
  */
-Hooks.Events.add("afterAddItemsToCart", (cartId) => {
+Hooks.Events.add("afterAddItemsToCart", (cartId, options) => {
   // Adding a new product or variant to the cart
   Logger.debug("after cart update, call inventory/addReserve");
-  // Look up cart to get items that have been added to it
-  const cart = Cart.findOne({ _id: cartId });
-  Meteor.call("inventory/addReserve", cart.items);
+  // Look up cart to get items added to it
+  const items = Cart.findOne({ _id: cartId }).items;
+  // Reserve item
+  Meteor.call("inventory/addReserve", items.filter(item => item._id === options.newItemId));
 });
 
-Hooks.Events.add("afterModifyQuantityInCart", (cartId) => {
+Hooks.Events.add("afterModifyQuantityInCart", (cartId, options) => {
   // Modifying item quantity in cart.
   Logger.debug("after variant increment, call inventory/addReserve");
   // Look up cart to get items that have been added to it
-  const cart = Cart.findOne({ _id: cartId });
-  Meteor.call("inventory/addReserve", cart.items);
+  const items = Cart.findOne({ _id: cartId }).items;
+  // Item to increment quantity
+  const item = items.filter(i => i.productId === options.productId && i.variantId === options.variantId);
+  Meteor.call("inventory/addReserve", item);
 });
 
 /**
  * Before cart update. When Item is removed from Cart, release the inventory reservation.
  */
-Hooks.Events.add("beforeRemoveItemsFromCart", (cartId) => {
+Hooks.Events.add("beforeRemoveItemsFromCart", (cartItem) => {
   // removing  cart items, clear inventory reserve
   Logger.debug("remove cart items, call inventory/clearReserve");
   // Look up cart to get items that have been removed from it
-  const cart = Cart.findOne({ _id: cartId });
-  Meteor.call("inventory/clearReserve", cart.items);
+  Meteor.call("inventory/clearReserve", cartItem);
 });
 
 /**

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -1,29 +1,35 @@
 import { Meteor } from "meteor/meteor";
-import { Products, Orders } from "/lib/collections";
+import { Cart, Products, Orders } from "/lib/collections";
 import { Logger, Hooks } from "/server/api";
 import { registerInventory } from "../methods/inventory";
 
 /**
  * After cart update add invetory reservations
  */
-Hooks.Events.add("afterAddItemsToCart", (userId, cart) => {
+Hooks.Events.add("afterAddItemsToCart", (cartId) => {
   // Adding a new product or variant to the cart
   Logger.debug("after cart update, call inventory/addReserve");
+  // Look up cart to get items that have been added to it
+  const cart = Cart.findOne({ _id: cartId });
   Meteor.call("inventory/addReserve", cart.items);
 });
 
-Hooks.Events.add("afterModifyQuantityInCart", (userId, cart) => {
+Hooks.Events.add("afterModifyQuantityInCart", (cartId) => {
   // Modifying item quantity in cart.
   Logger.debug("after variant increment, call inventory/addReserve");
+  // Look up cart to get items that have been added to it
+  const cart = Cart.findOne({ _id: cartId });
   Meteor.call("inventory/addReserve", cart.items);
 });
 
 /**
  * Before cart update. When Item is removed from Cart, release the inventory reservation.
  */
-Hooks.Events.add("beforeRemoveItemsFromCart", (userId, cart) => {
+Hooks.Events.add("beforeRemoveItemsFromCart", (cartId) => {
   // removing  cart items, clear inventory reserve
   Logger.debug("remove cart items, call inventory/clearReserve");
+  // Look up cart to get items that have been removed from it
+  const cart = Cart.findOne({ _id: cartId });
   Meteor.call("inventory/clearReserve", cart.items);
 });
 

--- a/server/methods/core/cart-remove.app-test.js
+++ b/server/methods/core/cart-remove.app-test.js
@@ -52,7 +52,9 @@ describe("cart methods", function () {
       const cartItemId = cartFromCollection.items[0]._id;
       assert.equal(cartFromCollection.items.length, 2);
       Meteor.call("cart/removeFromCart", cartItemId);
-      assert.equal(updateSpy.callCount, 1, "update should be called one time");
+      // Expect Cart.update to be called twice, because cart/removeFromCart
+      // triggers a Hooks.Events which calls Cart.update.
+      assert.equal(updateSpy.callCount, 2, "update should be called one time");
       Meteor._sleepForMs(1000);
       const updatedCart = Collections.Cart.findOne(cart._id);
       assert.equal(updatedCart.items.length, 1, "there should be one item left in cart");

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -199,6 +199,9 @@ Meteor.methods({
             items: { $each: mergedItems, $slice: -(mergedItems.length) }
           }
         });
+
+        // Calculate discounts
+        Hooks.Events.run("afterCartUpdateCalculateDiscount", currentCart._id);
       }
 
       // cleanup session Carts after merge.
@@ -429,6 +432,8 @@ Meteor.methods({
         throw error;
       }
 
+      // Calculate discounts
+      Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
       // refresh shipping quotes
       Meteor.call("shipping/updateShipmentQuotes", cart._id);
       // revert workflow to checkout shipping step.
@@ -491,6 +496,8 @@ Meteor.methods({
       throw error;
     }
 
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
     // refresh shipping quotes
     Meteor.call("shipping/updateShipmentQuotes", cart._id);
     // revert workflow to checkout shipping step.
@@ -560,6 +567,8 @@ Meteor.methods({
 
       Logger.debug(`cart: deleted cart item variant id ${cartItem.variants._id}`);
 
+      // Calculate discounts
+      Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
       // TODO: HACK: When calling update shipping the changes to the cart have not taken place yet
       // TODO: But calling this findOne seems to force this record to update. Extra weird since we aren't
       // TODO: passing the Cart but just the cartId and regrabbing it so you would think that would work but it does not
@@ -594,8 +603,9 @@ Meteor.methods({
       throw error;
     }
 
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
     Logger.debug(`cart: removed variant ${cartItem._id} quantity of ${quantity}`);
-
     // refresh shipping quotes
     Meteor.call("shipping/updateShipmentQuotes", cart._id);
     // revert workflow
@@ -671,6 +681,10 @@ Meteor.methods({
       throw new Meteor.Error("server-error", "An error occurred saving the order", e);
     }
 
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
+
     // this will transition to review
     return Meteor.call(
       "workflow/pushCartWorkflow", "coreCartWorkflow",
@@ -732,6 +746,9 @@ Meteor.methods({
       Logger.error(e);
       throw new Meteor.Error("server-error", "An error occurred adding the currency");
     }
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
 
     return true;
   },
@@ -885,6 +902,9 @@ Meteor.methods({
     // refresh shipping quotes
     Meteor.call("shipping/updateShipmentQuotes", cartId);
 
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
+
     if (typeof cart.workflow !== "object") {
       throw new Meteor.Error(
         "server-error",
@@ -966,7 +986,12 @@ Meteor.methods({
       };
     }
 
-    return Collections.Cart.update(selector, update);
+    const result = Collections.Cart.update(selector, update);
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
+
+    return result;
   },
 
   /**
@@ -1027,6 +1052,9 @@ Meteor.methods({
         Logger.error(e);
         throw new Meteor.Error("server-error", "Error updating cart");
       }
+
+      // Calculate discounts
+      Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
 
       if (isShippingDeleting) {
         // if we remove shipping address from cart, we need to revert
@@ -1137,6 +1165,9 @@ Meteor.methods({
       Logger.error(e);
       throw new Meteor.Error("server-error", "An error occurred saving the order");
     }
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
 
     return Collections.Cart.findOne(selector);
   },

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -541,10 +541,11 @@ Meteor.methods({
       throw new Meteor.Error("not-found", "Unable to find an item with such id in cart.");
     }
 
+    Hooks.Events.run("beforeRemoveItemsFromCart", userId, cart);
+
     if (!quantity || quantity >= cartItem.quantity) {
       let cartResult;
       try {
-        Hooks.Events.run("beforeRemoveItemsFromCart", userId, cart);
         cartResult = Collections.Cart.update({
           _id: cart._id
         }, {

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -428,7 +428,7 @@ Meteor.methods({
       }
 
       // Update inventory
-      Hooks.Events.run("afterModifyQuantityInCart", cart._id);
+      Hooks.Events.run("afterModifyQuantityInCart", cart._id, { productId, variantId });
       // Calculate discounts
       Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
       // refresh shipping quotes
@@ -459,6 +459,7 @@ Meteor.methods({
     }
     // cart variant doesn't exist
     let updateResult;
+    const newItemId = Random.id();
 
     try {
       updateResult = Collections.Cart.update({
@@ -466,7 +467,7 @@ Meteor.methods({
       }, {
         $addToSet: {
           items: {
-            _id: Random.id(),
+            _id: newItemId,
             shopId: product.shopId,
             productId,
             quantity,
@@ -489,7 +490,7 @@ Meteor.methods({
     }
 
     // Update add inventory reserve
-    Hooks.Events.run("afterAddItemsToCart", cart._id);
+    Hooks.Events.run("afterAddItemsToCart", cart._id, { newItemId });
     // Calculate discounts
     Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
     // refresh shipping quotes
@@ -535,7 +536,7 @@ Meteor.methods({
       throw new Meteor.Error("not-found", "Unable to find an item with such id in cart.");
     }
 
-    Hooks.Events.run("beforeRemoveItemsFromCart", cart._id);
+    Hooks.Events.run("beforeRemoveItemsFromCart", [cartItem]);
 
     if (!quantity || quantity >= cartItem.quantity) {
       let cartResult;

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -417,11 +417,6 @@ Meteor.methods({
             "items.$.quantity": quantity
           },
           ...modifier
-        }, (error, response) => {
-          // Update inventory
-          if (response) {
-            Hooks.Events.run("afterModifyQuantityInCart", this.userId, cart);
-          }
         });
       } catch (error) {
         Logger.error("Error adding to cart.", error);
@@ -432,6 +427,8 @@ Meteor.methods({
         throw error;
       }
 
+      // Update inventory
+      Hooks.Events.run("afterModifyQuantityInCart", cart._id);
       // Calculate discounts
       Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
       // refresh shipping quotes
@@ -481,11 +478,6 @@ Meteor.methods({
             parcel
           }
         }
-      }, (error, response) => {
-        if (response) {
-          // Update inventory
-          Hooks.Events.run("afterAddItemsToCart", this.userId, cart);
-        }
       });
     } catch (error) {
       Logger.error("Error adding to cart.", error);
@@ -496,6 +488,8 @@ Meteor.methods({
       throw error;
     }
 
+    // Update add inventory reserve
+    Hooks.Events.run("afterAddItemsToCart", cart._id);
     // Calculate discounts
     Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
     // refresh shipping quotes
@@ -541,7 +535,7 @@ Meteor.methods({
       throw new Meteor.Error("not-found", "Unable to find an item with such id in cart.");
     }
 
-    Hooks.Events.run("beforeRemoveItemsFromCart", userId, cart);
+    Hooks.Events.run("beforeRemoveItemsFromCart", cart._id);
 
     if (!quantity || quantity >= cartItem.quantity) {
       let cartResult;

--- a/server/methods/core/payments.js
+++ b/server/methods/core/payments.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { Reaction } from "/server/api";
+import { Reaction, Hooks } from "/server/api";
 
 /**
  * @file Methods for Payments. Run these methods using `Meteor.call()`.
@@ -27,13 +27,18 @@ export const methods = {
     check(collection, String);
     const Collection = Reaction.Collections[collection];
 
-    return Collection.update({
+    const result = Collection.update({
       _id: id
     }, {
       $addToSet: {
         billing: { paymentMethod }
       }
     });
+
+    // calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", id);
+
+    return result;
   }
 };
 

--- a/server/methods/core/shipping.js
+++ b/server/methods/core/shipping.js
@@ -41,6 +41,9 @@ function createShipmentQuotes(cartId, shopId, rates) {
     throw error;
   }
 
+  // Calculate discounts
+  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
+
   Logger.debug(`Success in setting shipping query status to "pending" for ${cartId}`, rates);
 
   if (rates.length === 1 && rates[0].requestStatus === "error") {
@@ -105,6 +108,9 @@ function pruneShippingRecordsByShop(cart) {
         }
       );
     }
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
   }
 }
 
@@ -138,6 +144,8 @@ function normalizeAddresses(cart) {
         }
       };
       Cart.update(selector, update);
+      // Calculate discounts
+      Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
     });
   }
 }
@@ -165,6 +173,9 @@ function updateShipmentQuotes(cartId, rates, selector) {
     Logger.warn(`Error in setting shipping query status to "pending" for ${cartId}`, error);
     throw error;
   }
+
+  // Calculate discounts
+  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
 
   Logger.debug(`Success in setting shipping query status to "pending" for ${cartId}`, rates);
 
@@ -229,6 +240,9 @@ function updateShippingRecordByShop(cart, rates) {
       Logger.warn(`Error updating rates for cart ${cartId}`, error);
       throw error;
     }
+
+    // Calculate discounts
+    Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
 
     Logger.debug(`Success updating rates for cart ${cartId}`, rates);
   });


### PR DESCRIPTION

Resolves: #1 3635
Impact: Minor
Type: Refactor

Issue
The cart uses hooks from meteor-collection-hooks package, this package will be removed.

Solution
Convert cart collection hooks to use Reaction's Hooks.Events.

Testing Instructions
Discounts

Set a discount code and discount amount, a value of 10 would translate to 10% off
Add a product to the cart
checkout and apply the discount code
Finish checkout and verify order confirmation email shows the discount.
Adding items to cart

Add an item to the cart
Verify the corresponding inventory document has its workflow field set to reserved
Removing item from cart

Add item to cart
Remove item from cart
Verify the corresponding inventory document has its workflow field set to new